### PR TITLE
Led on/off on TapDance

### DIFF
--- a/keymaps/default/keymap.c
+++ b/keymaps/default/keymap.c
@@ -98,6 +98,13 @@ void matrix_init_user(void) {
 }
 
 void matrix_scan_user(void) {
+        if (keyboard_report->mods & MOD_BIT(KC_LSFT) ||
+            ((get_oneshot_mods() & MOD_BIT(KC_LSFT)) && !has_oneshot_mods_timed_out())) {
+                icekeys_led_on();
+        } else {
+                icekeys_led_off();
+        }
+
         LEADER_DICTIONARY() {
                 leading = false;
                 leader_end();


### PR DESCRIPTION
The led is controller also during the tap dance functionality.
Whenever the User taps the LShift, the led turns on for all the time
that the tap dance is active. when is deactivated, also the led is
turned off.